### PR TITLE
Tweak the async README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Task.ordered {
 
 ### NSXPCConnection
 
-You might be tempted to make your XPC interface functions `async`. This does not handle connection failures and can hang your `Task`s because it violates the Structured Concurrency contract, so it is unsafe.
+You might be tempted to make your XPC interface functions `async`. This does not handle connection failures and can hang your `Task`s because it violates the Structured Concurrency contract, so it is unsafe. [See the post "ExtensionKit and XPC" for context.](https://www.chimehq.com/blog/extensionkit-xpc)
 
 This little `NSXPCConnection` extension provides a safe way to get into the async world.
 


### PR DESCRIPTION
Found a typo ("Mmethod") and missing `func`s, so I tried to smooth things over. Used trailing closures without parens because the rest of the README doesn't wrap it in parens, either. Please do pick nits if something doesn't look right :)
